### PR TITLE
Fix signing keychain export in release workflows

### DIFF
--- a/.github/workflows/release-rehearsal.yml
+++ b/.github/workflows/release-rehearsal.yml
@@ -190,7 +190,9 @@ jobs:
         run: |
           OUTPUT_DIR="$RUNNER_TEMP/release-signing" \
           ./scripts/release-prepare-signing-keychain.sh
-          cat "$RUNNER_TEMP/release-signing/signing-keychain.env" >> "$GITHUB_ENV"
+          source "$RUNNER_TEMP/release-signing/signing-keychain.env"
+          test -n "$SIGNING_KEYCHAIN_PATH"
+          echo "SIGNING_KEYCHAIN_PATH=$SIGNING_KEYCHAIN_PATH" >> "$GITHUB_ENV"
 
       - name: Produce signed candidate and evidence bundle
         env:
@@ -218,5 +220,7 @@ jobs:
       - name: Cleanup keychain and credentials
         if: always()
         run: |
-          rm -f "$RUNNER_TEMP/certificate.p12"
-          security delete-keychain "$RUNNER_TEMP/signing.keychain-db" 2>/dev/null || true
+          if [[ -n "${SIGNING_KEYCHAIN_PATH:-}" ]]; then
+            security delete-keychain "$SIGNING_KEYCHAIN_PATH" 2>/dev/null || true
+          fi
+          rm -rf "$RUNNER_TEMP/release-signing"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,7 +173,9 @@ jobs:
         run: |
           OUTPUT_DIR="$RUNNER_TEMP/release-signing" \
           ./scripts/release-prepare-signing-keychain.sh
-          cat "$RUNNER_TEMP/release-signing/signing-keychain.env" >> "$GITHUB_ENV"
+          source "$RUNNER_TEMP/release-signing/signing-keychain.env"
+          test -n "$SIGNING_KEYCHAIN_PATH"
+          echo "SIGNING_KEYCHAIN_PATH=$SIGNING_KEYCHAIN_PATH" >> "$GITHUB_ENV"
 
       - name: Produce signed candidate and evidence bundle
         env:
@@ -209,8 +211,10 @@ jobs:
       - name: Cleanup keychain and credentials
         if: always()
         run: |
-          rm -f "$RUNNER_TEMP/certificate.p12"
-          security delete-keychain "$RUNNER_TEMP/signing.keychain-db" 2>/dev/null || true
+          if [[ -n "${SIGNING_KEYCHAIN_PATH:-}" ]]; then
+            security delete-keychain "$SIGNING_KEYCHAIN_PATH" 2>/dev/null || true
+          fi
+          rm -rf "$RUNNER_TEMP/release-signing"
 
   publish:
     name: Attest and publish release


### PR DESCRIPTION
## Summary
- source the shell-style signing env file before writing `SIGNING_KEYCHAIN_PATH` into `GITHUB_ENV`
- assert that the keychain path resolved before the signing step runs
- clean up the actual temporary signing keychain path instead of a stale hard-coded path

## Why
The temp keychain helper writes `export SIGNING_KEYCHAIN_PATH=...` for local shell usage. Appending that file directly to `GITHUB_ENV` left the variable unset in GitHub Actions, which broke the signed-candidate job on `main`.

## Verification
- actionlint .github/workflows/release-rehearsal.yml .github/workflows/release.yml
- just check